### PR TITLE
Vis saksbehandlingvarsel for hele saken

### DIFF
--- a/client/src/mocks/data/behovsmeldinger/behovsmelding_1.json
+++ b/client/src/mocks/data/behovsmeldinger/behovsmelding_1.json
@@ -2,6 +2,15 @@
   "behovsmeldingId": "1e3f5513-a394-4f59-9020-07a35cb4c7e8",
   "beskrivelse": "behovsmelding_1",
   "behovsmelding": {
+    "saksbehandlingvarsel": [
+      {
+        "tekst": {
+          "nb": "Denne søknaden ble meldt inn sammen med et bytte, men ble automatisk delt opp i to saker. Sakene kan inneholde hjelpemidler som bør behandles samlet. Byttesaken inneholder følgende hjelpemidler: 326540 Cross 6 sb35 sd42-55 lang",
+          "nn": "Denne søknaden ble meldt inn sammen med et bytte, men ble automatisk delt opp i to saker. Sakene kan inneholde hjelpemidler som bør behandles samlet. Byttesaken inneholder følgende hjelpemidler: 326540 Cross 6 sb35 sd42-55 lang"
+        },
+        "type": "WARNING"
+      }
+    ],
     "bruker": {
       "fnr": "13820599335",
       "navn": {

--- a/client/src/mocks/data/behovsmeldinger/behovsmelding_2.json
+++ b/client/src/mocks/data/behovsmeldinger/behovsmelding_2.json
@@ -2,6 +2,7 @@
   "behovsmeldingId": "5de2e7c3-60fa-42e5-8fe6-1258cb3cf4e8",
   "beskrivelse": "behovsmelding_2",
   "behovsmelding": {
+    "saksbehandlingvarsel": [],
     "bruker": {
       "fnr": "13820599335",
       "navn": {

--- a/client/src/mocks/data/behovsmeldinger/behovsmelding_3.json
+++ b/client/src/mocks/data/behovsmeldinger/behovsmelding_3.json
@@ -2,6 +2,7 @@
   "behovsmeldingId": "02b6ee2a-59fe-481f-ada5-c583726bfd1b",
   "beskrivelse": "behovsmelding_3",
   "behovsmelding": {
+    "saksbehandlingvarsel": [],
     "bruker": {
       "fnr": "13820599335",
       "navn": { "fornavn": "Kvadratisk", "mellomnavn": null, "etternavn": "Faktura" },

--- a/client/src/mocks/data/behovsmeldinger/behovsmelding_alle_hjelpemidler_utlevert.json
+++ b/client/src/mocks/data/behovsmeldinger/behovsmelding_alle_hjelpemidler_utlevert.json
@@ -2,6 +2,7 @@
   "behovsmeldingId": "d6dfceb6-9ea0-4871-9b09-707b52e4d2d9",
   "beskrivelse": "behovsmelding_6",
   "behovsmelding": {
+    "saksbehandlingvarsel": [],
     "bruker": {
       "fnr": "13820599335",
       "navn": { "fornavn": "Kvadratisk", "mellomnavn": null, "etternavn": "Faktura" },

--- a/client/src/mocks/data/behovsmeldinger/behovsmelding_hentes_på_hjelpemiddelsentral.json
+++ b/client/src/mocks/data/behovsmeldinger/behovsmelding_hentes_på_hjelpemiddelsentral.json
@@ -2,6 +2,7 @@
   "behovsmeldingId": "5a734ee0-84b4-44ee-897b-570c7842b85d",
   "beskrivelse": "behovsmelding_5",
   "behovsmelding": {
+    "saksbehandlingvarsel": [],
     "bruker": {
       "fnr": "13820599335",
       "navn": { "fornavn": "Kvadratisk", "mellomnavn": null, "etternavn": "Faktura" },

--- a/client/src/mocks/data/behovsmeldinger/behovsmelding_hjelpemidler_utlevert_alle_opsjoner.json
+++ b/client/src/mocks/data/behovsmeldinger/behovsmelding_hjelpemidler_utlevert_alle_opsjoner.json
@@ -2,6 +2,7 @@
   "behovsmeldingId": "cde6615e-be9f-449f-b39d-eff7ea1909df",
   "beskrivelse": "behovsmelding_4",
   "behovsmelding": {
+    "saksbehandlingvarsel": [],
     "bruker": {
       "fnr": "13820599335",
       "navn": { "fornavn": "Kvadratisk", "mellomnavn": null, "etternavn": "Faktura" },

--- a/client/src/mocks/data/behovsmeldinger/demo/hotsak_demo_2_avslag.json
+++ b/client/src/mocks/data/behovsmeldinger/demo/hotsak_demo_2_avslag.json
@@ -2,6 +2,7 @@
   "behovsmeldingId": "02b6ee2a-59fe-481f-ada5-c583726bfd1b",
   "beskrivelse": "behovsmelding_3",
   "behovsmelding": {
+    "saksbehandlingvarsel": [],
     "bruker": {
       "fnr": "01056605014",
       "navn": { "fornavn": "Ola", "mellomnavn": null, "etternavn": "Nordmann" },

--- a/client/src/mocks/data/behovsmeldinger/demo/hotsak_demo_2_enkel.json
+++ b/client/src/mocks/data/behovsmeldinger/demo/hotsak_demo_2_enkel.json
@@ -2,6 +2,7 @@
   "behovsmeldingId": "4802ed92-aa84-48b4-97b2-c89118e25898",
   "beskrivelse": "importert",
   "behovsmelding": {
+    "saksbehandlingvarsel": [],
     "id": "4802ed92-aa84-48b4-97b2-c89118e25898",
     "type": "SØKNAD",
     "bruker": {

--- a/client/src/mocks/data/behovsmeldinger/importert/02b6ee2a-59fe-481f-ada5-c583726bfd1b.json
+++ b/client/src/mocks/data/behovsmeldinger/importert/02b6ee2a-59fe-481f-ada5-c583726bfd1b.json
@@ -3,6 +3,7 @@
   "beskrivelse": "importert",
   "behovsmelding": {
     "id": "02b6ee2a-59fe-481f-ada5-c583726bfd1b",
+    "saksbehandlingvarsel": [],
     "type": "SØKNAD",
     "bruker": {
       "fnr": "13820599335",

--- a/client/src/mocks/data/behovsmeldinger/importert/16a7d8cf-882c-40e4-9d7a-35de4b080386.json
+++ b/client/src/mocks/data/behovsmeldinger/importert/16a7d8cf-882c-40e4-9d7a-35de4b080386.json
@@ -3,6 +3,7 @@
   "beskrivelse": "importert",
   "behovsmelding": {
     "id": "16a7d8cf-882c-40e4-9d7a-35de4b080386",
+    "saksbehandlingvarsel": [],
     "type": "BESTILLING",
     "bruker": {
       "fnr": "13820599335",

--- a/client/src/mocks/data/behovsmeldinger/importert/4802ed92-aa84-48b4-97b2-c89118e25898.json
+++ b/client/src/mocks/data/behovsmeldinger/importert/4802ed92-aa84-48b4-97b2-c89118e25898.json
@@ -3,6 +3,7 @@
   "beskrivelse": "importert",
   "behovsmelding": {
     "id": "4802ed92-aa84-48b4-97b2-c89118e25898",
+    "saksbehandlingvarsel": [],
     "type": "SØKNAD",
     "bruker": {
       "fnr": "13820599335",

--- a/client/src/mocks/data/behovsmeldinger/importert/6dc594b7-35fe-4b04-8378-4b4ed0bc250e.json
+++ b/client/src/mocks/data/behovsmeldinger/importert/6dc594b7-35fe-4b04-8378-4b4ed0bc250e.json
@@ -3,6 +3,7 @@
   "beskrivelse": "importert",
   "behovsmelding": {
     "id": "6dc594b7-35fe-4b04-8378-4b4ed0bc250e",
+    "saksbehandlingvarsel": [],
     "type": "SØKNAD",
     "bruker": {
       "fnr": "13820599335",

--- a/client/src/mocks/data/behovsmeldinger/importert/86b464a7-3684-46a4-8240-d14ab5c7be7d.json
+++ b/client/src/mocks/data/behovsmeldinger/importert/86b464a7-3684-46a4-8240-d14ab5c7be7d.json
@@ -3,6 +3,7 @@
   "beskrivelse": "importert",
   "behovsmelding": {
     "id": "86b464a7-3684-46a4-8240-d14ab5c7be7d",
+    "saksbehandlingvarsel": [],
     "type": "SØKNAD",
     "bruker": {
       "fnr": "13820599335",

--- a/client/src/mocks/data/behovsmeldinger/importert/87d7736e-3e40-4e8b-a7b9-c003beca44e8.json
+++ b/client/src/mocks/data/behovsmeldinger/importert/87d7736e-3e40-4e8b-a7b9-c003beca44e8.json
@@ -3,6 +3,7 @@
   "beskrivelse": "importert",
   "behovsmelding": {
     "id": "87d7736e-3e40-4e8b-a7b9-c003beca44e8",
+    "saksbehandlingvarsel": [],
     "type": "BESTILLING",
     "bruker": {
       "fnr": "13820599335",

--- a/client/src/mocks/data/behovsmeldinger/importert/cc32e266-5bb6-46fb-bf87-ef532b369171.json
+++ b/client/src/mocks/data/behovsmeldinger/importert/cc32e266-5bb6-46fb-bf87-ef532b369171.json
@@ -3,6 +3,7 @@
   "beskrivelse": "importert",
   "behovsmelding": {
     "id": "cc32e266-5bb6-46fb-bf87-ef532b369171",
+    "saksbehandlingvarsel": [],
     "type": "SØKNAD",
     "bruker": {
       "fnr": "13820599335",

--- a/client/src/mocks/data/behovsmeldinger/importert/cc5c0ec1-b1a0-4642-8ae1-88af7042694c.json
+++ b/client/src/mocks/data/behovsmeldinger/importert/cc5c0ec1-b1a0-4642-8ae1-88af7042694c.json
@@ -3,6 +3,7 @@
   "beskrivelse": "importert",
   "behovsmelding": {
     "id": "cc5c0ec1-b1a0-4642-8ae1-88af7042694c",
+    "saksbehandlingvarsel": [],
     "type": "BESTILLING",
     "bruker": {
       "fnr": "26848497710",

--- a/client/src/mocks/data/behovsmeldinger/importert/e345551d-0c6a-47e6-83a8-3853f2710951.json
+++ b/client/src/mocks/data/behovsmeldinger/importert/e345551d-0c6a-47e6-83a8-3853f2710951.json
@@ -3,6 +3,7 @@
   "beskrivelse": "importert",
   "behovsmelding": {
     "id": "e345551d-0c6a-47e6-83a8-3853f2710951",
+    "saksbehandlingvarsel": [],
     "type": "SØKNAD",
     "bruker": {
       "fnr": "13820599335",

--- a/client/src/mocks/data/behovsmeldinger/importert/fd7b7002-9662-450a-98df-05ba234bcbf4.json
+++ b/client/src/mocks/data/behovsmeldinger/importert/fd7b7002-9662-450a-98df-05ba234bcbf4.json
@@ -3,6 +3,7 @@
   "beskrivelse": "importert",
   "behovsmelding": {
     "id": "fd7b7002-9662-450a-98df-05ba234bcbf4",
+    "saksbehandlingvarsel": [],
     "type": "SØKNAD",
     "bruker": {
       "fnr": "13820599335",

--- a/client/src/saksbilde/hjelpemidler/HjelpemiddelListe.tsx
+++ b/client/src/saksbilde/hjelpemidler/HjelpemiddelListe.tsx
@@ -17,6 +17,7 @@ import {
   useProduktLagerInfo,
 } from './useAlternativeProdukter.ts'
 import { useHjelpemiddelprodukter } from './useHjelpemiddelprodukter.ts'
+import { Varsler } from './Varsel.tsx'
 
 interface HjelpemiddelListeProps {
   sak: Sak
@@ -27,7 +28,7 @@ function HjelpemiddelListe({ sak, behovsmelding }: HjelpemiddelListeProps) {
   const { artikler } = useArtiklerForSak(sak.sakId)
 
   const artiklerSomIkkeFinnesIOebs = artikler.filter((artikkel) => !artikkel.finnesIOebs)
-  const { brukersituasjon, levering } = behovsmelding
+  const { brukersituasjon, levering, saksbehandlingvarsel } = behovsmelding
   const hjelpemidler = behovsmelding.hjelpemidler.hjelpemidler
   const tilbehør = behovsmelding.hjelpemidler.tilbehør
 
@@ -55,6 +56,7 @@ function HjelpemiddelListe({ sak, behovsmelding }: HjelpemiddelListeProps) {
       <Heading level="1" size="small" visuallyHidden={true}>
         {storForbokstavIOrd(sak.sakstype)}
       </Heading>
+      {saksbehandlingvarsel.length > 0 && <Varsler varsler={saksbehandlingvarsel} />}
       {levering.hast && <Hast hast={levering.hast} />}
 
       {hjelpemidler.length > 0 && (

--- a/client/src/types/BehovsmeldingTypes.ts
+++ b/client/src/types/BehovsmeldingTypes.ts
@@ -10,6 +10,7 @@ export interface Innsenderbehovsmelding {
   brukersituasjon: Brukersituasjon
   hjelpemidler: Hjelpemidler
   levering: Levering
+  saksbehandlingvarsel: Varsel[]
 }
 
 export enum BehovsmeldingType {


### PR DESCRIPTION
Dette bruker `saksbehandlingvarsel` fra APIet, som defaulter til en tom liste i [Innsenderbehovsmelding-modellen](https://github.com/navikt/hotlibs/blob/main/behovsmelding/src/main/kotlin/no/nav/hjelpemidler/behovsmeldingsmodell/v2/Innsenderbehovsmelding.kt#L43).

Ref [tråd på Slack](https://nav-it.slack.com/archives/G01GC2CFY6L/p1768397007023999).